### PR TITLE
Improve haversine accuracy

### DIFF
--- a/q-code/haversine.q
+++ b/q-code/haversine.q
@@ -13,7 +13,7 @@ pi: acos -1
 
 / Declare the radius of the Earth (in kilometres), and assign it a value. 
 
-radiusInKilometres: 6371
+radiusInKilometres: 6371.0088
 
 
 //------------HELPER FUNCTIONS------------//
@@ -40,9 +40,10 @@ toRadian:{pi * x % 180}
 / Function: haversineDistance - returns a distance between two points (lat/lon pairs) that is useably accurate for a large number of use cases
 / params - w, x represent lat/lon pair 1, while y, z correspond to  lat/lon pair 2 
 
-haversineDistance:{[w;x;y;z]
-	radiusInKilometres*(2*atan2SquareRoots[(sinP[(toRadian[((y)-(w))])]+sinP[(toRadian[((z)-(x))])]*(cos(toRadian[w]))*(cos(toRadian[y])))])
-	}
+haversineDistance:{[w;x;y;z]  
+	d:xexp[sin(-[toRadian[y];toRadian[w]]*0.5);2] + (((cos(toRadian[w])) * cos(toRadian[y])) * xexp[sin(-[toRadian[z];toRadian[x]]*0.5);2]);
+	(2 * radiusInKilometres) * asin(sqrt(d))
+ }
 
 
 / How To Use:


### PR DESCRIPTION
Hey @andymans,

I really appreciate you adding this repo as it helped in a recent task for calculating distances between two sets of co-ordinates.

I found that accuracy was increasingly lost over longer distances, so I forked it and updated it to align with other modules (inspired by [Python's haversine module](https://github.com/mapado/haversine)).

For example, Sydney to Belfast was coming out over 18279km vs 17103km.

Some examples with this update comparing q and Python:
![image](https://user-images.githubusercontent.com/24537293/209147266-1c67b278-f9fe-4a9d-aef7-dcbe33ac812f.png)

Regards,
David 